### PR TITLE
Enable Google Sheets form recording

### DIFF
--- a/GOOGLE_APPS_SCRIPT.md
+++ b/GOOGLE_APPS_SCRIPT.md
@@ -1,0 +1,35 @@
+# Registro de confirmaciones en Google Sheets
+
+Para guardar cada respuesta del formulario en la hoja de cálculo y enviar una copia por correo se puede usar un Google Apps Script.
+
+1. Abrir [la planilla](https://docs.google.com/spreadsheets/d/10rUuW9rKVIxR3e18DWR321lsH4GZBVlpv_r6dq8qZ_c/edit?usp=sharing) con la cuenta de Gmail.
+2. Crear un nuevo script desde `Extensiones -> Apps Script` y pegar el siguiente código:
+
+```javascript
+function doPost(e) {
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Respuestas');
+  if (!sheet) {
+    sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet('Respuestas');
+  }
+  sheet.appendRow([
+    new Date(),
+    e.parameter.nombre,
+    e.parameter.asiste,
+    e.parameter.restricciones
+  ]);
+
+  MailApp.sendEmail('casoriolauymanu@gmail.com', 'Nueva confirmación',
+    'Nombre: ' + e.parameter.nombre + '\n' +
+    'Asiste: ' + e.parameter.asiste + '\n' +
+    'Restricciones: ' + (e.parameter.restricciones || 'Sin datos'));
+
+  return ContentService.createTextOutput('ok');
+}
+```
+
+3. Guardar y desplegar el script seleccionando **Deploy -> New deployment**, tipo **Web app**. Elegir que pueda ser ejecutado por *Anyone*.
+4. Copiar la URL que genera el despliegue. En este proyecto ya se configuró la URL
+   `https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec`
+   para que cada formulario envíe sus datos automáticamente.
+
+Con esa configuración, cada vez que se envíe el formulario los datos se agregarán a la hoja y se enviará un mail a la cuenta indicada.

--- a/agustin.html
+++ b/agustin.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Agustín"> Agustín</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/angeles.html
+++ b/angeles.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tucu"> Tucu</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/belen-y-guido.html
+++ b/belen-y-guido.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Belen"> Belen</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/camila-lujan.html
+++ b/camila-lujan.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Camila Lujan"> Camila Lujan</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/carolina.html
+++ b/carolina.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Carolina"> Carolina</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/claudia-y-alejo.html
+++ b/claudia-y-alejo.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Claudia"> Claudia</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/consty.html
+++ b/consty.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Consty"> Consty</label>
@@ -343,6 +343,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/cristina-y-gustavo.html
+++ b/cristina-y-gustavo.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Cristina"> Cristina</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/denisse.html
+++ b/denisse.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Denisse"> Denisse</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/diego.html
+++ b/diego.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Diego"> Diego</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/dolores.html
+++ b/dolores.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Dolores"> Dolores</label>
@@ -343,6 +343,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/emi.html
+++ b/emi.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Emi"> Emi</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/eva-fuentes.html
+++ b/eva-fuentes.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tucu"> Tucu</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/familia-banfi.html
+++ b/familia-banfi.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ladislao"> Ladislao</label>
@@ -343,6 +343,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/familia-lucas-romi.html
+++ b/familia-lucas-romi.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Romina"> Romina</label>
@@ -343,6 +343,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/familia-nestor-sandra.html
+++ b/familia-nestor-sandra.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Sandra"> Sandra</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/fede-lopez.html
+++ b/fede-lopez.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Fede López"> Fede López</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/felipe.html
+++ b/felipe.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Felipe"> Felipe</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/felisa.html
+++ b/felisa.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Federico"> Federico</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/fernando.html
+++ b/fernando.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Lelé"> Lelé</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/flia-maunier.html
+++ b/flia-maunier.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jose Luis"> Jose Luis</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/flor-fuentes.html
+++ b/flor-fuentes.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Franco"> Franco</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/flor-maguicha.html
+++ b/flor-maguicha.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Flor Maguicha"> Flor Maguicha</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/florencia.html
+++ b/florencia.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Florencia"> Florencia</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/guido.html
+++ b/guido.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Guido"> Guido</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/hector-masuh.html
+++ b/hector-masuh.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Hector Masuh"> Hector Masuh</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/inaki.html
+++ b/inaki.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Iñaki"> Iñaki</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-    <form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+    <form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
       <label>Nombre y apellido:
         <input type="text" name="nombre" required />
       </label>
@@ -322,7 +322,7 @@
     });
     const cuenta = document.getElementById("cuenta-regresiva");
     const fechaObjetivo = new Date("2025-10-04T00:00:00").getTime();
-    const interval = setInterval(() => {
+  const interval = setInterval(() => {
       const ahora = new Date().getTime();
       const diferencia = fechaObjetivo - ahora;
       if (diferencia < 0) {
@@ -334,8 +334,17 @@
       const horas = Math.floor((diferencia % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
       const minutos = Math.floor((diferencia % (1000 * 60 * 60)) / (1000 * 60));
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
-      cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
-    }, 1000);
+  cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
+  }, 1000);
+
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
   </script>
 </body>
 </html>

--- a/ivana.html
+++ b/ivana.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ivana"> Ivana</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/javier-y-jazmin.html
+++ b/javier-y-jazmin.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Javier"> Javier</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/jeronimo.html
+++ b/jeronimo.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jerónimo"> Jerónimo</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/joaquin.html
+++ b/joaquin.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Joaquín"> Joaquín</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/jony.html
+++ b/jony.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jony"> Jony</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/josefina-juan.html
+++ b/josefina-juan.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Josefina"> Josefina</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/juan-cruz.html
+++ b/juan-cruz.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Caro"> Caro</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/juan-pablo.html
+++ b/juan-pablo.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Juan Pablo"> Juan Pablo</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/leila.html
+++ b/leila.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Leila"> Leila</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/leon.html
+++ b/leon.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="León"> León</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/manuel-y-laureana.html
+++ b/manuel-y-laureana.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Manuel"> Manuel</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/mariana.html
+++ b/mariana.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Catalina"> Catalina</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/mariel.html
+++ b/mariel.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Guille"> Guille</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/mechi.html
+++ b/mechi.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Mechi"> Mechi</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/micaela.html
+++ b/micaela.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Micaela"> Micaela</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/miguel.html
+++ b/miguel.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Miguel"> Miguel</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/nani.html
+++ b/nani.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Nani"> Nani</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/nazareno.html
+++ b/nazareno.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Nazareno"> Nazareno</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/owen.html
+++ b/owen.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ivan"> Ivan</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/paula-gonzalo-felicitas-matias-agustin.html
+++ b/paula-gonzalo-felicitas-matias-agustin.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Paula"> Paula</label>
@@ -344,6 +344,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/paulita.html
+++ b/paulita.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Fabián"> Fabián</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/ramiro.html
+++ b/ramiro.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ramiro"> Ramiro</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/ricardo.html
+++ b/ricardo.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ricardo"> Ricardo</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/rodo.html
+++ b/rodo.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Rodo"> Rodo</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/sebastian.html
+++ b/sebastian.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Sebastián"> Sebastián</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/teresa-daniela-daniel.html
+++ b/teresa-daniela-daniel.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Teresa"> Teresa</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/teresa.html
+++ b/teresa.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Daniela"> Daniela</label>
@@ -342,6 +342,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/tio-agustin.html
+++ b/tio-agustin.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Agustín"> Agustín</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/tomas.html
+++ b/tomas.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tomás"> Tomás</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/toto-y-mariana.html
+++ b/toto-y-mariana.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Toto"> Toto</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/valeria.html
+++ b/valeria.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Gustavo"> Gustavo</label>
@@ -341,6 +341,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>

--- a/victoria.html
+++ b/victoria.html
@@ -269,7 +269,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
+<form id="confirm-form" action="https://formsubmit.co/casoriolauymanu@gmail.com" method="POST">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Victoria"> Victoria</label>
@@ -340,6 +340,15 @@
       const segundos = Math.floor((diferencia % (1000 * 60)) / 1000);
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
-  </script>
+  
+    // Enviar datos también a Google Sheets mediante un Apps Script
+    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    const confirmForm = document.getElementById('confirm-form');
+    confirmForm.addEventListener('submit', (e) => {
+      // se envía en segundo plano a Google Sheets
+      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+        .catch(err => console.error('Error enviando a Google Sheets', err));
+    });
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow form data to also be sent to a Google Apps Script
- document how to deploy a script to store replies and send email
- apply the script configuration to all guest pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68878fc92540832682ea4e8539cfc373