### PR TITLE
Update invite forms to POST with no‑cors

### DIFF
--- a/agustin.html
+++ b/agustin.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/angeles.html
+++ b/angeles.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/belen-y-guido.html
+++ b/belen-y-guido.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/camila-lujan.html
+++ b/camila-lujan.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/carolina.html
+++ b/carolina.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/claudia-y-alejo.html
+++ b/claudia-y-alejo.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/consty.html
+++ b/consty.html
@@ -289,8 +289,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -349,7 +347,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/cristina-y-gustavo.html
+++ b/cristina-y-gustavo.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/denisse.html
+++ b/denisse.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/diego.html
+++ b/diego.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/dolores.html
+++ b/dolores.html
@@ -289,8 +289,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -349,7 +347,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/emi.html
+++ b/emi.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/eva-fuentes.html
+++ b/eva-fuentes.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/familia-banfi.html
+++ b/familia-banfi.html
@@ -289,8 +289,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -349,7 +347,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/familia-lucas-romi.html
+++ b/familia-lucas-romi.html
@@ -289,8 +289,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -349,7 +347,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/familia-nestor-sandra.html
+++ b/familia-nestor-sandra.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/fede-lopez.html
+++ b/fede-lopez.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/felipe.html
+++ b/felipe.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/felisa.html
+++ b/felisa.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/fernando.html
+++ b/fernando.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/flia-maunier.html
+++ b/flia-maunier.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/flor-fuentes.html
+++ b/flor-fuentes.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/flor-maguicha.html
+++ b/flor-maguicha.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/florencia.html
+++ b/florencia.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/guido.html
+++ b/guido.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/hector-masuh.html
+++ b/hector-masuh.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/inaki.html
+++ b/inaki.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
   </script>

--- a/ivana.html
+++ b/ivana.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/javier-y-jazmin.html
+++ b/javier-y-jazmin.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/jeronimo.html
+++ b/jeronimo.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/joaquin.html
+++ b/joaquin.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/jony.html
+++ b/jony.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/josefina-juan.html
+++ b/josefina-juan.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/juan-cruz.html
+++ b/juan-cruz.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/juan-pablo.html
+++ b/juan-pablo.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/leila.html
+++ b/leila.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/leon.html
+++ b/leon.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/manuel-y-laureana.html
+++ b/manuel-y-laureana.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/mariana.html
+++ b/mariana.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/mariel.html
+++ b/mariel.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/mechi.html
+++ b/mechi.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/micaela.html
+++ b/micaela.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/miguel.html
+++ b/miguel.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/nani.html
+++ b/nani.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/nazareno.html
+++ b/nazareno.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/owen.html
+++ b/owen.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/paula-gonzalo-felicitas-matias-agustin.html
+++ b/paula-gonzalo-felicitas-matias-agustin.html
@@ -290,8 +290,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -350,7 +348,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/paulita.html
+++ b/paulita.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/ramiro.html
+++ b/ramiro.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/ricardo.html
+++ b/ricardo.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/rodo.html
+++ b/rodo.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/sebastian.html
+++ b/sebastian.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/teresa-daniela-daniel.html
+++ b/teresa-daniela-daniel.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/teresa.html
+++ b/teresa.html
@@ -288,8 +288,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -348,7 +346,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/tio-agustin.html
+++ b/tio-agustin.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/tomas.html
+++ b/tomas.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/toto-y-mariana.html
+++ b/toto-y-mariana.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/valeria.html
+++ b/valeria.html
@@ -287,8 +287,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -347,7 +345,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 

--- a/victoria.html
+++ b/victoria.html
@@ -286,8 +286,6 @@
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
     <button type="submit">Enviar</button>
-    <input type="hidden" name="_next" value="https://graciasporconfirmar.com">
-    <input type="hidden" name="_captcha" value="false">
   </form>
   </section>
 
@@ -346,7 +344,7 @@
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', body: new FormData(confirmForm) })
+      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
 


### PR DESCRIPTION
## Summary
- use `mode: 'no-cors'` for Google Sheets submission
- drop leftover `_next` and `_captcha` inputs

## Testing
- `grep -n "mode: 'no-cors'" -R *.html | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_68879979646c8326b286eb00d4b0856a