### PR TITLE
Estilo material y email unificado

### DIFF
--- a/GOOGLE_APPS_SCRIPT.md
+++ b/GOOGLE_APPS_SCRIPT.md
@@ -1,37 +1,21 @@
-# Registro de confirmaciones en Google Sheets
+# Envío de confirmaciones por correo
 
-Para guardar cada respuesta del formulario en la hoja de cálculo y enviar una copia por correo se puede usar un Google Apps Script.
+Para que cada respuesta del formulario se envíe por correo electrónico podés usar un Google Apps Script sencillo.
 
-1. Abrir [la planilla](https://docs.google.com/spreadsheets/d/10rUuW9rKVIxR3e18DWR321lsH4GZBVlpv_r6dq8qZ_c/edit?usp=sharing) con la cuenta de Gmail.
-2. Crear un nuevo script desde `Extensiones -> Apps Script` y pegar el siguiente código:
+1. Abrí [Google Apps Script](https://script.google.com/) con tu cuenta de Gmail y creá un proyecto nuevo.
+2. Pegá el siguiente código:
 
 ```javascript
 function doPost(e) {
-  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Respuestas');
-  if (!sheet) {
-    sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet('Respuestas');
-  }
-  sheet.appendRow([
-    new Date(),
-    e.parameter.nombre,
-    e.parameter.asiste,
-    e.parameter.restricciones
-  ]);
-
   MailApp.sendEmail('casoriolauymanu@gmail.com', 'Nueva confirmación',
-    'Nombre: ' + e.parameter.nombre + '\n' +
-    'Asiste: ' + e.parameter.asiste + '\n' +
-    'Restricciones: ' + (e.parameter.restricciones || 'Sin datos'));
-
+    'Nombre: ' + (e.parameter.nombre || '') + '\n' +
+    'Asiste: ' + (e.parameter.asiste || '') + '\n' +
+    'Restricciones: ' + (e.parameter.restricciones || e.parameter.detalle_restriccion || 'Sin datos'));
   return ContentService.createTextOutput('ok');
 }
 ```
 
-3. Guardar y desplegar el script seleccionando **Deploy -> New deployment**, tipo **Web app**. Elegir que pueda ser ejecutado por *Anyone*.
-4. Copiar la URL que genera el despliegue. En este proyecto ya se configuró la URL
-   `https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec`
-   para que cada formulario envíe sus datos automáticamente.
+3. Desplegalo desde **Deploy -> New deployment** como **Web app** y permití que sea ejecutado por *Anyone*.
+4. Copiá la URL que genera el despliegue y usala como `action` o en la llamada `fetch` de cada formulario.
 
-Con esa configuración, cada vez que se envíe el formulario los datos se agregarán a la hoja y se enviará un mail a la cuenta indicada.
-
-**Nota:** No ejecutes la función *doPost* manualmente desde el editor porque el parámetro de evento `e` estará indefinido y aparecerá un error como 'Cannot read properties of undefined (reading \'parameter\')'. Debe desplegarse el script como Web App y luego enviarle la solicitud POST desde el formulario.
+Con esto cada envío llegará directamente a `casoriolauymanu@gmail.com` con los datos de confirmación.

--- a/agustin.html
+++ b/agustin.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/angeles.html
+++ b/angeles.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/belen-y-guido.html
+++ b/belen-y-guido.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/camila-lujan.html
+++ b/camila-lujan.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/carolina.html
+++ b/carolina.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/claudia-y-alejo.html
+++ b/claudia-y-alejo.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/consty.html
+++ b/consty.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -288,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -344,6 +345,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -353,5 +358,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/cristina-y-gustavo.html
+++ b/cristina-y-gustavo.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/denisse.html
+++ b/denisse.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/diego.html
+++ b/diego.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/dolores.html
+++ b/dolores.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -288,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -344,6 +345,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -353,5 +358,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/emi.html
+++ b/emi.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/eva-fuentes.html
+++ b/eva-fuentes.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/familia-banfi.html
+++ b/familia-banfi.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -288,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -344,6 +345,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -353,5 +358,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/familia-lucas-romi.html
+++ b/familia-lucas-romi.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -288,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -344,6 +345,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -353,5 +358,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/familia-nestor-sandra.html
+++ b/familia-nestor-sandra.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/fede-lopez.html
+++ b/fede-lopez.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/felipe.html
+++ b/felipe.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/felisa.html
+++ b/felisa.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/fernando.html
+++ b/fernando.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/flia-maunier.html
+++ b/flia-maunier.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/flor-fuentes.html
+++ b/flor-fuentes.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/flor-maguicha.html
+++ b/flor-maguicha.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/florencia.html
+++ b/florencia.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/guido.html
+++ b/guido.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/hector-masuh.html
+++ b/hector-masuh.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/inaki.html
+++ b/inaki.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -283,7 +284,7 @@
       <label>¿Tenés alguna restricción alimenticia?
         <textarea name="restricciones" rows="3"></textarea>
       </label>
-      <button type="submit">Enviar</button>
+      <button class="btn waves-effect waves-light" type="submit">Enviar</button>
     </form>
   </section>
 
@@ -339,6 +340,10 @@
 
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -347,5 +352,6 @@
         .catch(err => console.error('Error enviando a Google Sheets', err));
     });
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/ivana.html
+++ b/ivana.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/javier-y-jazmin.html
+++ b/javier-y-jazmin.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/jeronimo.html
+++ b/jeronimo.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/joaquin.html
+++ b/joaquin.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/jony.html
+++ b/jony.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/josefina-juan.html
+++ b/josefina-juan.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/juan-cruz.html
+++ b/juan-cruz.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/juan-pablo.html
+++ b/juan-pablo.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/leila.html
+++ b/leila.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/leon.html
+++ b/leon.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/manuel-y-laureana.html
+++ b/manuel-y-laureana.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/mariana.html
+++ b/mariana.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/mariel.html
+++ b/mariel.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/material.css
+++ b/material.css
@@ -1,0 +1,36 @@
+body {
+  font-family: 'Source Serif 4', serif;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+input[type="text"], input[type="email"], textarea, select {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #ccc;
+  color: inherit;
+  padding: 0.5rem 0.25rem;
+  border-radius: 0;
+  box-shadow: none;
+}
+input[type="text"]:focus, input[type="email"]:focus, textarea:focus, select:focus {
+  border-bottom: 2px solid #6200ea;
+  box-shadow: 0 1px 0 0 #6200ea;
+}
+label {
+  font-size: 0.9rem;
+  color: #eee;
+}
+button {
+  background-color: #6200ea;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.7rem 1.2rem;
+  cursor: pointer;
+}
+button:hover {
+  background-color: #3700b3;
+}

--- a/mechi.html
+++ b/mechi.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/micaela.html
+++ b/micaela.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/miguel.html
+++ b/miguel.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/nani.html
+++ b/nani.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/nazareno.html
+++ b/nazareno.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/owen.html
+++ b/owen.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/paula-gonzalo-felicitas-matias-agustin.html
+++ b/paula-gonzalo-felicitas-matias-agustin.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -289,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -345,6 +346,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -354,5 +359,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/paulita.html
+++ b/paulita.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/ramiro.html
+++ b/ramiro.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/ricardo.html
+++ b/ricardo.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/rodo.html
+++ b/rodo.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/sebastian.html
+++ b/sebastian.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/teresa-daniela-daniel.html
+++ b/teresa-daniela-daniel.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/teresa.html
+++ b/teresa.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -287,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,6 +344,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -352,5 +357,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/tio-agustin.html
+++ b/tio-agustin.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/tomas.html
+++ b/tomas.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/toto-y-mariana.html
+++ b/toto-y-mariana.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/valeria.html
+++ b/valeria.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -286,7 +287,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,6 +343,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -351,5 +356,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>

--- a/victoria.html
+++ b/victoria.html
@@ -206,6 +206,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="material.css">
 </head>
 <body>
   <nav>
@@ -285,7 +286,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,6 +342,10 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
+    document.addEventListener("DOMContentLoaded", function() {
+      var elems = document.querySelectorAll("select");
+      M.FormSelect.init(elems);
+    });
     const confirmForm = document.getElementById('confirm-form');
     confirmForm.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -350,5 +355,6 @@
     });
 
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Resumen
- nuevo archivo `material.css` con estilo inspirado en Material Design
- todos los formularios enlazan esta hoja y utilizan clases de Materialize
- inicialización de selects y botón con estilo
- documentación actualizada con script de Google Apps para enviar mail

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68881da3b0cc8326bbd807e23e3a396b