### PR TITLE
Estilo Material y envío corregido

### DIFF
--- a/GOOGLE_APPS_SCRIPT.md
+++ b/GOOGLE_APPS_SCRIPT.md
@@ -1,37 +1,24 @@
-# Registro de confirmaciones en Google Sheets
+# Envío de confirmaciones por correo
 
-Para guardar cada respuesta del formulario en la hoja de cálculo y enviar una copia por correo se puede usar un Google Apps Script.
+Para que cada respuesta del formulario se envíe por correo electrónico podés usar un Google Apps Script sencillo.
 
-1. Abrir [la planilla](https://docs.google.com/spreadsheets/d/10rUuW9rKVIxR3e18DWR321lsH4GZBVlpv_r6dq8qZ_c/edit?usp=sharing) con la cuenta de Gmail.
-2. Crear un nuevo script desde `Extensiones -> Apps Script` y pegar el siguiente código:
+1. Abrí [Google Apps Script](https://script.google.com/) con tu cuenta de Gmail y creá un proyecto nuevo.
+2. Pegá el siguiente código:
 
 ```javascript
 function doPost(e) {
-  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Respuestas');
-  if (!sheet) {
-    sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet('Respuestas');
-  }
-  sheet.appendRow([
-    new Date(),
-    e.parameter.nombre,
-    e.parameter.asiste,
-    e.parameter.restricciones
-  ]);
-
-  MailApp.sendEmail('casoriolauymanu@gmail.com', 'Nueva confirmación',
-    'Nombre: ' + e.parameter.nombre + '\n' +
-    'Asiste: ' + e.parameter.asiste + '\n' +
-    'Restricciones: ' + (e.parameter.restricciones || 'Sin datos'));
-
+  var datos = e.parameters;
+  var texto = Object.keys(datos).map(function(k) {
+    var v = datos[k];
+    if (Array.isArray(v)) v = v.join(', ');
+    return k + ': ' + v;
+  }).join('\n');
+  MailApp.sendEmail('casoriolauymanu@gmail.com', 'Nueva confirmación', texto);
   return ContentService.createTextOutput('ok');
 }
 ```
 
-3. Guardar y desplegar el script seleccionando **Deploy -> New deployment**, tipo **Web app**. Elegir que pueda ser ejecutado por *Anyone*.
-4. Copiar la URL que genera el despliegue. En este proyecto ya se configuró la URL
-   `https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec`
-   para que cada formulario envíe sus datos automáticamente.
+3. Desplegalo desde **Deploy -> New deployment** como **Web app** y permití que sea ejecutado por *Anyone*.
+4. Copiá la URL que genera el despliegue y usala como `action` o en la llamada `fetch` de cada formulario.
 
-Con esa configuración, cada vez que se envíe el formulario los datos se agregarán a la hoja y se enviará un mail a la cuenta indicada.
-
-**Nota:** No ejecutes la función *doPost* manualmente desde el editor porque el parámetro de evento `e` estará indefinido y aparecerá un error como 'Cannot read properties of undefined (reading \'parameter\')'. Debe desplegarse el script como Web App y luego enviarle la solicitud POST desde el formulario.
+Con esto cada envío llegará directamente a `casoriolauymanu@gmail.com` con los datos de confirmación.

--- a/agustin.html
+++ b/agustin.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Agustín"> Agustín</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/angeles.html
+++ b/angeles.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tucu"> Tucu</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/belen-y-guido.html
+++ b/belen-y-guido.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Belen"> Belen</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/camila-lujan.html
+++ b/camila-lujan.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Camila Lujan"> Camila Lujan</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/carolina.html
+++ b/carolina.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Carolina"> Carolina</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/claudia-y-alejo.html
+++ b/claudia-y-alejo.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Claudia"> Claudia</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/consty.html
+++ b/consty.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Consty"> Consty</label>
@@ -288,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -344,12 +347,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/cristina-y-gustavo.html
+++ b/cristina-y-gustavo.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Cristina"> Cristina</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/denisse.html
+++ b/denisse.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Denisse"> Denisse</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/diego.html
+++ b/diego.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Diego"> Diego</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/dolores.html
+++ b/dolores.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Dolores"> Dolores</label>
@@ -288,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -344,12 +347,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/emi.html
+++ b/emi.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Emi"> Emi</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/eva-fuentes.html
+++ b/eva-fuentes.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tucu"> Tucu</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/familia-banfi.html
+++ b/familia-banfi.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ladislao"> Ladislao</label>
@@ -288,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -344,12 +347,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/familia-lucas-romi.html
+++ b/familia-lucas-romi.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Romina"> Romina</label>
@@ -288,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -344,12 +347,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/familia-nestor-sandra.html
+++ b/familia-nestor-sandra.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Sandra"> Sandra</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/fede-lopez.html
+++ b/fede-lopez.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Fede López"> Fede López</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/felipe.html
+++ b/felipe.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Felipe"> Felipe</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/felisa.html
+++ b/felisa.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Federico"> Federico</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/fernando.html
+++ b/fernando.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Lelé"> Lelé</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/flia-maunier.html
+++ b/flia-maunier.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jose Luis"> Jose Luis</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/flor-fuentes.html
+++ b/flor-fuentes.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Franco"> Franco</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/flor-maguicha.html
+++ b/flor-maguicha.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Flor Maguicha"> Flor Maguicha</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/florencia.html
+++ b/florencia.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Florencia"> Florencia</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/guido.html
+++ b/guido.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Guido"> Guido</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/hector-masuh.html
+++ b/hector-masuh.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Hector Masuh"> Hector Masuh</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/inaki.html
+++ b/inaki.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Iñaki"> Iñaki</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/index.html
+++ b/index.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-    <form id="confirm-form" method="POST">
+    <form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
       <label>Nombre y apellido:
         <input type="text" name="nombre" required />
       </label>
@@ -283,7 +286,7 @@
       <label>¿Tenés alguna restricción alimenticia?
         <textarea name="restricciones" rows="3"></textarea>
       </label>
-      <button type="submit">Enviar</button>
+      <button class="btn waves-effect waves-light" type="submit">Enviar</button>
     </form>
   </section>
 
@@ -339,12 +342,32 @@
 
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
   </script>
 </body>

--- a/ivana.html
+++ b/ivana.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ivana"> Ivana</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/javier-y-jazmin.html
+++ b/javier-y-jazmin.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Javier"> Javier</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/jeronimo.html
+++ b/jeronimo.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jerónimo"> Jerónimo</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/joaquin.html
+++ b/joaquin.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Joaquín"> Joaquín</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/jony.html
+++ b/jony.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jony"> Jony</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/josefina-juan.html
+++ b/josefina-juan.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Josefina"> Josefina</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/juan-cruz.html
+++ b/juan-cruz.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Caro"> Caro</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/juan-pablo.html
+++ b/juan-pablo.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Juan Pablo"> Juan Pablo</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/leila.html
+++ b/leila.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Leila"> Leila</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/leon.html
+++ b/leon.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="León"> León</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/manuel-y-laureana.html
+++ b/manuel-y-laureana.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Manuel"> Manuel</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/mariana.html
+++ b/mariana.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Catalina"> Catalina</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/mariel.html
+++ b/mariel.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Guille"> Guille</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/material.css
+++ b/material.css
@@ -1,0 +1,50 @@
+body {
+  font-family: 'Source Serif 4', serif;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+input[type="text"], input[type="email"], textarea, select {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #ccc;
+  color: inherit;
+  padding: 0.5rem 0.25rem;
+  border-radius: 0;
+  box-shadow: none;
+}
+input[type="text"]:focus, input[type="email"]:focus, textarea:focus, select:focus {
+  border-bottom: 2px solid #6200ea;
+  box-shadow: 0 1px 0 0 #6200ea;
+}
+label {
+  font-size: 0.9rem;
+  color: #eee;
+}
+button {
+  background-color: #6200ea;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.7rem 1.2rem;
+  cursor: pointer;
+}
+button:hover {
+  background-color: #3700b3;
+}
+
+input[type="checkbox"] {
+  opacity: 1 !important;
+  position: static !important;
+  pointer-events: auto;
+  margin-right: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    background-size: contain !important;
+  }
+}
+

--- a/mechi.html
+++ b/mechi.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Mechi"> Mechi</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/micaela.html
+++ b/micaela.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Micaela"> Micaela</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/miguel.html
+++ b/miguel.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Miguel"> Miguel</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/nani.html
+++ b/nani.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Nani"> Nani</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/nazareno.html
+++ b/nazareno.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Nazareno"> Nazareno</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/owen.html
+++ b/owen.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ivan"> Ivan</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/paula-gonzalo-felicitas-matias-agustin.html
+++ b/paula-gonzalo-felicitas-matias-agustin.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Paula"> Paula</label>
@@ -289,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -345,12 +348,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/paulita.html
+++ b/paulita.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Fabián"> Fabián</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/ramiro.html
+++ b/ramiro.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ramiro"> Ramiro</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/ricardo.html
+++ b/ricardo.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ricardo"> Ricardo</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/rodo.html
+++ b/rodo.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Rodo"> Rodo</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/sebastian.html
+++ b/sebastian.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Sebastián"> Sebastián</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/teresa-daniela-daniel.html
+++ b/teresa-daniela-daniel.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Teresa"> Teresa</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/teresa.html
+++ b/teresa.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Daniela"> Daniela</label>
@@ -287,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,12 +346,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/tio-agustin.html
+++ b/tio-agustin.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Agustín"> Agustín</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/tomas.html
+++ b/tomas.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tomás"> Tomás</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/toto-y-mariana.html
+++ b/toto-y-mariana.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Toto"> Toto</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/valeria.html
+++ b/valeria.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Gustavo"> Gustavo</label>
@@ -286,7 +289,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,12 +345,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/victoria.html
+++ b/victoria.html
@@ -206,6 +206,9 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +272,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Victoria"> Victoria</label>
@@ -285,7 +288,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,12 +344,32 @@
   
     // Enviar datos también a Google Sheets mediante un Apps Script
     const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a Google Sheets', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>


### PR DESCRIPTION
## Resumen
- se agrega Materialize CSS y JS en todos los formularios
- cada formulario incluye la URL del Apps Script como `action`
- se reemplaza la lógica de envío para mostrar un mensaje con `M.toast`
- se quita el script redundante al final de las páginas
- ajustes para que la imagen de fondo en móvil se vea mejor y los checkboxes sean clickeables
- ejemplo de Apps Script más flexible para el correo

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68881da3b0cc8326bbd807e23e3a396b