### PR TITLE
Link de confirmación actualizado

### DIFF
--- a/GOOGLE_APPS_SCRIPT.md
+++ b/GOOGLE_APPS_SCRIPT.md
@@ -1,37 +1,17 @@
-# Registro de confirmaciones en Google Sheets
+# Envío de confirmaciones por correo
 
-Para guardar cada respuesta del formulario en la hoja de cálculo y enviar una copia por correo se puede usar un Google Apps Script.
+Para enviar los datos de los formularios por email se utiliza [FormSubmit](https://formsubmit.co), de modo que no es necesario programar un backend propio.
 
-1. Abrir [la planilla](https://docs.google.com/spreadsheets/d/10rUuW9rKVIxR3e18DWR321lsH4GZBVlpv_r6dq8qZ_c/edit?usp=sharing) con la cuenta de Gmail.
-2. Crear un nuevo script desde `Extensiones -> Apps Script` y pegar el siguiente código:
-
-```javascript
-function doPost(e) {
-  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Respuestas');
-  if (!sheet) {
-    sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet('Respuestas');
-  }
-  sheet.appendRow([
-    new Date(),
-    e.parameter.nombre,
-    e.parameter.asiste,
-    e.parameter.restricciones
-  ]);
-
-  MailApp.sendEmail('casoriolauymanu@gmail.com', 'Nueva confirmación',
-    'Nombre: ' + e.parameter.nombre + '\n' +
-    'Asiste: ' + e.parameter.asiste + '\n' +
-    'Restricciones: ' + (e.parameter.restricciones || 'Sin datos'));
-
-  return ContentService.createTextOutput('ok');
-}
-```
-
-3. Guardar y desplegar el script seleccionando **Deploy -> New deployment**, tipo **Web app**. Elegir que pueda ser ejecutado por *Anyone*.
-4. Copiar la URL que genera el despliegue. En este proyecto ya se configuró la URL
-   `https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec`
-   para que cada formulario envíe sus datos automáticamente.
-
-Con esa configuración, cada vez que se envíe el formulario los datos se agregarán a la hoja y se enviará un mail a la cuenta indicada.
-
-**Nota:** No ejecutes la función *doPost* manualmente desde el editor porque el parámetro de evento `e` estará indefinido y aparecerá un error como 'Cannot read properties of undefined (reading \'parameter\')'. Debe desplegarse el script como Web App y luego enviarle la solicitud POST desde el formulario.
+1. Registrá la cuenta `casoriolauymanu@gmail.com` en el sitio de FormSubmit.
+2. El formulario puede apuntar directamente al servicio con:
+   ```html
+   <form action="https://formsubmit.co/el/digaza" method="POST">
+   ```
+3. En el código se usa la versión AJAX de la URL para mostrar un mensaje sin abandonar la página:
+   ```javascript
+   const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+   fetch(emailServiceURL, { method: 'POST', body: new FormData(form) })
+     .then(() => M.toast({html: '¡Confirmación enviada! Gracias.'}))
+     .catch(() => M.toast({html: 'Ocurrió un error, intentá nuevamente.'}));
+   ```
+4. Con esto cada envío llegará a la casilla indicada con los datos del formulario.

--- a/agustin.html
+++ b/agustin.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Agustín"> Agustín</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/angeles.html
+++ b/angeles.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tucu"> Tucu</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/belen-y-guido.html
+++ b/belen-y-guido.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Belen"> Belen</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/camila-lujan.html
+++ b/camila-lujan.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Camila Lujan"> Camila Lujan</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/carolina.html
+++ b/carolina.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Carolina"> Carolina</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/claudia-y-alejo.html
+++ b/claudia-y-alejo.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Claudia"> Claudia</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/consty.html
+++ b/consty.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Consty"> Consty</label>
@@ -288,7 +293,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,14 +347,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/cristina-y-gustavo.html
+++ b/cristina-y-gustavo.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Cristina"> Cristina</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/denisse.html
+++ b/denisse.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Denisse"> Denisse</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/diego.html
+++ b/diego.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Diego"> Diego</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/dolores.html
+++ b/dolores.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Dolores"> Dolores</label>
@@ -288,7 +293,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,14 +347,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/emi.html
+++ b/emi.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Emi"> Emi</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/eva-fuentes.html
+++ b/eva-fuentes.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tucu"> Tucu</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/familia-banfi.html
+++ b/familia-banfi.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ladislao"> Ladislao</label>
@@ -288,7 +293,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,14 +347,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/familia-lucas-romi.html
+++ b/familia-lucas-romi.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Romina"> Romina</label>
@@ -288,7 +293,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -342,14 +347,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/familia-nestor-sandra.html
+++ b/familia-nestor-sandra.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Sandra"> Sandra</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/fede-lopez.html
+++ b/fede-lopez.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Fede López"> Fede López</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/felipe.html
+++ b/felipe.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Felipe"> Felipe</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/felisa.html
+++ b/felisa.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Federico"> Federico</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/fernando.html
+++ b/fernando.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Lelé"> Lelé</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/flia-maunier.html
+++ b/flia-maunier.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jose Luis"> Jose Luis</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/flor-fuentes.html
+++ b/flor-fuentes.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Franco"> Franco</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/flor-maguicha.html
+++ b/flor-maguicha.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Flor Maguicha"> Flor Maguicha</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/florencia.html
+++ b/florencia.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Florencia"> Florencia</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/guido.html
+++ b/guido.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Guido"> Guido</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/hector-masuh.html
+++ b/hector-masuh.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Hector Masuh"> Hector Masuh</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/inaki.html
+++ b/inaki.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Iñaki"> Iñaki</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/index.html
+++ b/index.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-    <form id="confirm-form" method="POST">
+    <form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
       <label>Nombre y apellido:
         <input type="text" name="nombre" required />
       </label>
@@ -283,7 +288,7 @@
       <label>¿Tenés alguna restricción alimenticia?
         <textarea name="restricciones" rows="3"></textarea>
       </label>
-      <button type="submit">Enviar</button>
+      <button class="btn waves-effect waves-light" type="submit">Enviar</button>
     </form>
   </section>
 
@@ -337,14 +342,34 @@
   cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
   }, 1000);
 
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
   </script>
 </body>

--- a/ivana.html
+++ b/ivana.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ivana"> Ivana</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/javier-y-jazmin.html
+++ b/javier-y-jazmin.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Javier"> Javier</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/jeronimo.html
+++ b/jeronimo.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jerónimo"> Jerónimo</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/joaquin.html
+++ b/joaquin.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Joaquín"> Joaquín</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/jony.html
+++ b/jony.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Jony"> Jony</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/josefina-juan.html
+++ b/josefina-juan.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Josefina"> Josefina</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/juan-cruz.html
+++ b/juan-cruz.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Caro"> Caro</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/juan-pablo.html
+++ b/juan-pablo.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Juan Pablo"> Juan Pablo</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/leila.html
+++ b/leila.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Leila"> Leila</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/leon.html
+++ b/leon.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="León"> León</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/manuel-y-laureana.html
+++ b/manuel-y-laureana.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Manuel"> Manuel</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/mariana.html
+++ b/mariana.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Catalina"> Catalina</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/mariel.html
+++ b/mariel.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Guille"> Guille</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/material.css
+++ b/material.css
@@ -1,0 +1,51 @@
+body {
+  font-family: 'Source Serif 4', serif;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+input[type="text"], input[type="email"], textarea, select {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #ccc;
+  color: inherit;
+  padding: 0.5rem 0.25rem;
+  border-radius: 0;
+  box-shadow: none;
+}
+input[type="text"]:focus, input[type="email"]:focus, textarea:focus, select:focus {
+  border-bottom: 2px solid #6200ea;
+  box-shadow: 0 1px 0 0 #6200ea;
+}
+label {
+  font-size: 0.9rem;
+  color: #eee;
+}
+button {
+  background-color: #6200ea;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.7rem 1.2rem;
+  cursor: pointer;
+}
+button:hover {
+  background-color: #3700b3;
+}
+
+input[type="checkbox"] {
+  opacity: 1 !important;
+  position: static !important;
+  pointer-events: auto;
+  margin-right: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    background-size: contain !important;
+    background-repeat: repeat !important;
+  }
+}
+

--- a/mechi.html
+++ b/mechi.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Mechi"> Mechi</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/micaela.html
+++ b/micaela.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Micaela"> Micaela</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/miguel.html
+++ b/miguel.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Miguel"> Miguel</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/nani.html
+++ b/nani.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Nani"> Nani</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/nazareno.html
+++ b/nazareno.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Nazareno"> Nazareno</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/owen.html
+++ b/owen.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ivan"> Ivan</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/paula-gonzalo-felicitas-matias-agustin.html
+++ b/paula-gonzalo-felicitas-matias-agustin.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Paula"> Paula</label>
@@ -289,7 +294,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -343,14 +348,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/paulita.html
+++ b/paulita.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Fabián"> Fabián</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/ramiro.html
+++ b/ramiro.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ramiro"> Ramiro</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/ricardo.html
+++ b/ricardo.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Ricardo"> Ricardo</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/rodo.html
+++ b/rodo.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Rodo"> Rodo</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/sebastian.html
+++ b/sebastian.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Sebastián"> Sebastián</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/teresa-daniela-daniel.html
+++ b/teresa-daniela-daniel.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Teresa"> Teresa</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/teresa.html
+++ b/teresa.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Daniela"> Daniela</label>
@@ -287,7 +292,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -341,14 +346,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/tio-agustin.html
+++ b/tio-agustin.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Agustín"> Agustín</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/tomas.html
+++ b/tomas.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Tomás"> Tomás</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/toto-y-mariana.html
+++ b/toto-y-mariana.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Toto"> Toto</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/valeria.html
+++ b/valeria.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Gustavo"> Gustavo</label>
@@ -286,7 +291,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -340,14 +345,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>

--- a/victoria.html
+++ b/victoria.html
@@ -203,9 +203,14 @@
       }
       body {
         background-attachment: scroll;
+        background-size: contain;
+        background-repeat: repeat;
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+  <link rel="stylesheet" href="material.css">
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 </head>
 <body>
   <nav>
@@ -269,7 +274,7 @@
 </section>
   <section id="confirmacion">
     <h2>Confirmación de asistencia</h2>
-<form id="confirm-form" method="POST">
+<form id="confirm-form" method="POST" action="https://formsubmit.co/el/digaza">
     <fieldset>
       <legend>¿Quiénes asisten?</legend>
       <label><input type="checkbox" name="asistentes[]" value="Victoria"> Victoria</label>
@@ -285,7 +290,7 @@
     </select>
     <label for="detalle">Aclaración (Nombre y detalle):</label>
     <textarea name="detalle_restriccion" rows="3"></textarea>
-    <button type="submit">Enviar</button>
+    <button class="btn waves-effect waves-light" type="submit">Enviar</button>
   </form>
   </section>
 
@@ -339,14 +344,34 @@
       cuenta.innerHTML = `${dias} días, ${horas} horas, ${minutos} minutos y ${segundos} segundos`;
     }, 1000);
   
-    // Enviar datos también a Google Sheets mediante un Apps Script
-    const googleScriptURL = 'https://script.google.com/macros/s/AKfycbw_Cf0X778WWDDKCoT0MUgEv3Tce90fjXv252auaELvaYiioGBuKIGzwcZUkbijyfUx/exec';
-    const confirmForm = document.getElementById('confirm-form');
-    confirmForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      // se envía en segundo plano a Google Sheets
-      fetch(googleScriptURL, { method: 'POST', mode: 'no-cors', body: new FormData(confirmForm) })
-        .catch(err => console.error('Error enviando a Google Sheets', err));
+    // Enviar datos con FormSubmit
+    const emailServiceURL = 'https://formsubmit.co/ajax/el/digaza';
+    document.addEventListener('DOMContentLoaded', function() {
+      var elems = document.querySelectorAll('select');
+      if (window.M && M.FormSelect) {
+        M.FormSelect.init(elems);
+      }
+      const confirmForm = document.getElementById('confirm-form');
+      confirmForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        fetch(emailServiceURL, { method: 'POST', body: new FormData(confirmForm) })
+          .then(function() {
+            if (window.M && M.toast) {
+              M.toast({html: '¡Confirmación enviada! Gracias.'});
+            } else {
+              alert('¡Confirmación enviada! Gracias.');
+            }
+            confirmForm.reset();
+          })
+          .catch(function(err) {
+            console.error('Error enviando a FormSubmit', err);
+            if (window.M && M.toast) {
+              M.toast({html: 'Ocurrió un error, intentá nuevamente.'});
+            } else {
+              alert('Ocurrió un error, intentá nuevamente.');
+            }
+          });
+      });
     });
 
   </script>


### PR DESCRIPTION
## Resumen
- se reemplaza el enlace de FormSubmit por `https://formsubmit.co/el/digaza`
- actualizados todos los formularios y el script de envío
- documentación adaptada con la nueva URL

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68881da3b0cc8326bbd807e23e3a396b